### PR TITLE
Fix MacOS button display issues

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -2,6 +2,7 @@
 Global configuration and shared state for Jetlag UK Map Maker
 """
 from pathlib import Path
+import platform
 
 # Project root = folder where config.py lives
 BASE_DIR = Path(__file__).resolve().parents[1]
@@ -13,8 +14,8 @@ LOCAL_DATA_DIR = BASE_DIR / "local_data_outputs"
 LOCAL_DATA_DIR.mkdir(exist_ok=True)
 
 # ----------------- COLOURS -----------------
-BG = "#1B2A40"        # Background
-FG = "#FFFFFF"        # Foreground / text
+BG = "#1B2A40" if platform.system() != "Darwin" else None       # Background
+FG = "#FFFFFF" if platform.system() != "Darwin" else None       # Foreground / text
 BTN = "#F68B1F"       # Buttons / accents
 DANGER = "#D21F2D"    # Errors / destructive actions
 


### PR DESCRIPTION
In reference to #2:
The issue was the BG colour would not apply to MacOS buttons properly. As such the FG colour was unreadable on the MacOS white BG. By removing the custom colouring on MacOS this issue is "fixed', although the UI looks ass.
<img width="1014" height="642" alt="image" src="https://github.com/user-attachments/assets/71b97d9c-2c52-405a-a44e-bebbfa8e5ca8" />
Using the default colours does make it look MacOSy, but the only other options I see are splitting out text and button text FG, or making the BG colour a light colour and the FG a dark colour.
<img width="1027" height="650" alt="image" src="https://github.com/user-attachments/assets/e5e7b3ad-4ad2-4758-99ae-9284bc933148" />
