### PR TITLE
Fix errors used by using None - instead use light mode colours

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -14,8 +14,8 @@ LOCAL_DATA_DIR = BASE_DIR / "local_data_outputs"
 LOCAL_DATA_DIR.mkdir(exist_ok=True)
 
 # ----------------- COLOURS -----------------
-BG = "#1B2A40" if platform.system() != "Darwin" else None       # Background
-FG = "#FFFFFF" if platform.system() != "Darwin" else None       # Foreground / text
+BG = "#1B2A40" if platform.system() != "Darwin" else "#ececec"       # Background
+FG = "#FFFFFF" if platform.system() != "Darwin" else "#000000"       # Foreground / text
 BTN = "#F68B1F"       # Buttons / accents
 DANGER = "#D21F2D"    # Errors / destructive actions
 


### PR DESCRIPTION
Probably should've better tested 😳  (on a side note I've put in the default colours for MacOS light mode. This does look quite ugly in dark mode.... but it's useable).